### PR TITLE
fix typo

### DIFF
--- a/src/estimation/krig.jl
+++ b/src/estimation/krig.jl
@@ -131,7 +131,7 @@ function preprocess(problem::EstimationProblem, solver::Kriging)
 end
 
 function solve(problem::EstimationProblem, solver::Kriging)
-  # retrive problem info
+  # retrieve problem info
   pdomain = domain(problem)
 
   # preprocess user input


### PR DESCRIPTION
dumped repo strings exposed a solitary typo

```
$ grep -nr retrive GeoStatsSolvers.jl
GeoStatsSolvers.jl/src/estimation/krig.jl:134:  # retrive problem info
$ 
```